### PR TITLE
README: fix consistent quoting and add reserved keyword example

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,10 @@ Input `my_schema.json`:
     "name": "Q",
     "type": "TIMESTAMP",
     "mode": "REPEATED"
+  },
+  {
+    "name": "date",
+    "type": "DATE"
   }
 ]
 ```
@@ -162,7 +166,8 @@ SELECT
     ORDER BY
       OFFSET
   ) AS L,
-  Q
+  Q,
+  `date`
 ```
 
 In case you would like to use snake_case for field names use flag `--use_snake_case`:


### PR DESCRIPTION
Update README example to match current script logic:
- Standard fields are unquoted.
- Reserved keywords (`date`) are automatically backticked.
- Added `date` field to the bottom of the JSON/SQL example as requested.